### PR TITLE
Change fog distance from statute miles to nautical miles

### DIFF
--- a/src/core/fsguinewflightdialog.cpp
+++ b/src/core/fsguinewflightdialog.cpp
@@ -641,7 +641,7 @@ void FsGuiNewFlightDialogClass::InitializeDialog(FsWorld *world,const FsNewFligh
 		if(info.envInfo.fog==YSTRUE)
 		{
 			v=info.envInfo.fogVisibility;
-			v/=1609.0;
+			v/=1852.0;
 			visibility->SetNumber((int)v);
 		}
 		else
@@ -925,7 +925,7 @@ void FsGuiNewFlightDialogClass::OnNumberBoxChange(FsGuiNumberBox *nbx,int prevNu
 		if(nbx==visibility)
 		{
 			info.envInfo.fog=YSTRUE;
-			info.envInfo.fogVisibility=(double)nbx->GetNumber()*1609.0;
+			info.envInfo.fogVisibility=(double)nbx->GetNumber()*1852.0;
 		}
 
 


### PR DESCRIPTION
I noticed a couple of other instances of `1609.0` in `fsguinewflightdialog.cpp` related to the fog visibility distance. I changed these to `1852.0` so that these distances are in nautical miles.