### PR TITLE
Radar warning receiver on HUD + radar drawing changes

### DIFF
--- a/src/config/fsconfig.cpp
+++ b/src/config/fsconfig.cpp
@@ -40,7 +40,7 @@ void FsFlightConfig::SetDefault(void)
 	drawTransparentVapor=YSTRUE;
 	drawTransparentSmoke=YSTRUE;
 	drawTransparentLater=YSTRUE;
-
+	drawCircleRadar = YSFALSE;
 	drawPlayerNameAlways=YSTRUE;
 	drawLightsInDaylight=YSTRUE;
 	drawLightsInDaylightVisibilityThr=4667.1; // 2.9 miles visibility.

--- a/src/config/fsconfig.cpp
+++ b/src/config/fsconfig.cpp
@@ -41,6 +41,7 @@ void FsFlightConfig::SetDefault(void)
 	drawTransparentSmoke=YSTRUE;
 	drawTransparentLater=YSTRUE;
 	drawCircleRadar = YSFALSE;
+	drawRWR = YSTRUE;
 	drawPlayerNameAlways=YSTRUE;
 	drawLightsInDaylight=YSTRUE;
 	drawLightsInDaylightVisibilityThr=4667.1; // 2.9 miles visibility.

--- a/src/config/fsconfig.h
+++ b/src/config/fsconfig.h
@@ -53,6 +53,7 @@ public:
 	YSBOOL drawTransparentVapor;
 	YSBOOL drawTransparentSmoke;
 	YSBOOL drawTransparentLater;
+	YSBOOL drawCircleRadar;
 	YSBOOL useOpenGlListForCloud;
 	YSBOOL useOpenGlListForExplosion;
 	YSBOOL useOpenGlListForWeapon;

--- a/src/config/fsconfig.h
+++ b/src/config/fsconfig.h
@@ -53,6 +53,7 @@ public:
 	YSBOOL drawTransparentVapor;
 	YSBOOL drawTransparentSmoke;
 	YSBOOL drawTransparentLater;
+	YSBOOL drawRWR;
 	YSBOOL drawCircleRadar;
 	YSBOOL useOpenGlListForCloud;
 	YSBOOL useOpenGlListForExplosion;

--- a/src/core/fshud2.cpp
+++ b/src/core/fshud2.cpp
@@ -1853,7 +1853,7 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 	{
 		double altLimit = airAltLimit + 1000.0 * (1.0 - currAir->Prop().GetRadarCrossSection());
 		if (currAir != withRespectTo 
-			&& currAir->IsAlive() == YSTRUE 
+			&& currAir->IsActive() == YSTRUE
 			&& currAir->GetPosition().y() > altLimit
 			&& (currAir->GetPosition() - withRespectTo->GetPosition()).GetSquareLengthXZ() <= searchRadius * searchRadius)
 		{

--- a/src/core/fshud2.cpp
+++ b/src/core/fshud2.cpp
@@ -1872,8 +1872,8 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			//calculate start and end screen coordinates of current RWR line
 			double startX = radius * 0.05 * cos(radarAngle);
 			double startY = radius * 0.05 * sin(radarAngle);
-			double endX = radius * 0.85 * cos(radarAngle);
-			double endY = radius * 0.85 * sin(radarAngle);
+			double endX = radius * 0.65 * cos(radarAngle);
+			double endY = radius * 0.65 * sin(radarAngle);
 
 			lineVtxBuf.Add<double>(startX, startY, zPlane);
 			lineColBuf.Add(YsRed());
@@ -1901,8 +1901,8 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			}
 
 			//determine position of identifier letter and draw
-			double fontX = radius * cos(radarAngle);
-			double fontY = radius * sin(radarAngle);
+			double fontX = radius * 0.8 * cos(radarAngle);
+			double fontY = radius * 0.8 * sin(radarAngle);
 			double fontXOffset = idString.length() % 2 == 0 ? fontWidth * idString.length() + fontWidth / 2.0 : fontWidth * idString.length();
 			YsMatrix4x4 tfm;
 			tfm.Translate(fontX - fontXOffset, fontY, zPlane);
@@ -1940,9 +1940,9 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			double endY = radius * 0.85 * sin(radarAngle);
 
 			lineVtxBuf.Add<double>(startX, startY, zPlane);
-			lineColBuf.Add(hudCol);
+			lineColBuf.Add(YsYellow());
 			lineVtxBuf.Add<double>(endX, endY, zPlane);
-			lineColBuf.Add(hudCol);
+			lineColBuf.Add(YsYellow());
 
 			//determine RWR identifier based on aircraft category
 			std::string idString = "";
@@ -1985,7 +1985,7 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			YsMatrix4x4 tfm;
 			tfm.Translate(fontX - fontWidth / 2.0, fontY, zPlane);
 			tfm.Scale(fontWidth, fontHeight, 1.0);
-			FsAddWireFontVertexBuffer(lineVtxBuf, lineColBuf, triVtxBuf, triColBuf, tfm, idString.c_str(), hudCol);
+			FsAddWireFontVertexBuffer(lineVtxBuf, lineColBuf, triVtxBuf, triColBuf, tfm, idString.c_str(), YsYellow());
 			numThreatsDrawn++;
 		}
 	}
@@ -2018,9 +2018,9 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			double endY = radius * 0.85 * sin(radarAngle);
 
 			lineVtxBuf.Add<double>(startX, startY, zPlane);
-			lineColBuf.Add(hudCol);
+			lineColBuf.Add(YsYellow());
 			lineVtxBuf.Add<double>(endX, endY, zPlane);
-			lineColBuf.Add(hudCol);
+			lineColBuf.Add(YsYellow());
 
 			//determine position of identifier letter and draw
 			double fontX = radius * cos(radarAngle);
@@ -2028,7 +2028,7 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			YsMatrix4x4 tfm;
 			tfm.Translate(fontX - fontWidth / 2.0, fontY, zPlane);
 			tfm.Scale(fontWidth, fontHeight, 1.0);
-			FsAddWireFontVertexBuffer(lineVtxBuf, lineColBuf, triVtxBuf, triColBuf, tfm, "G", hudCol);
+			FsAddWireFontVertexBuffer(lineVtxBuf, lineColBuf, triVtxBuf, triColBuf, tfm, "G", YsYellow());
 			numThreatsDrawn++;
 		}
 	}

--- a/src/core/fshud2.cpp
+++ b/src/core/fshud2.cpp
@@ -1916,26 +1916,16 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 	FsAirplane* currAir = NULL;
 	while ((currAir = sim->FindNextAirplane(currAir)) != NULL && numThreatsDrawn < maxNumThreatsToDraw)
 	{
+		bool isLocking = currAir->Prop().GetAirTargetKey() == FsExistence::GetSearchKey(withRespectTo);
 		double altLimit = airAltLimit + 1000.0 * (1.0 - currAir->Prop().GetRadarCrossSection());
 		if (currAir != withRespectTo 
 			&& currAir->IsActive() == YSTRUE
 			&& currAir->GetPosition().y() > altLimit
-			&& (currAir->GetPosition() - withRespectTo->GetPosition()).GetSquareLengthXZ() <= searchRadius * searchRadius)
+			&& (currAir->GetPosition() - withRespectTo->GetPosition()).GetSquareLengthXZ() <= searchRadius * searchRadius
+			&& isLocking)
 		{
 			//check if current aircraft is locking onto us
-			bool isLocking = currAir->Prop().GetAirTargetKey() == FsExistence::GetSearchKey(withRespectTo);
-
-			//if the plane is locked onto us, draw in yellow
-			YsColor currColor;
-			if (isLocking)
-			{
-				currColor = YsYellow();
-			}
-			else
-			{
-				currColor = hudCol;
-			}
-
+			
 			//get relative position of current aircraft
 			YsVec3 relPosition;
 			ref.MulInverse(relPosition, currAir->Prop().GetPosition(), 1.0);
@@ -1943,27 +1933,16 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			//calculate relative angle in XZ plane
 			double radarAngle = atan2(relPosition.z(), relPosition.x());
 
-			//draw a longer RWR line marker if locking 
-			double startRadiusOffset;
-			if (isLocking)
-			{
-				startRadiusOffset = 0.05;
-			}
-			else
-			{
-				startRadiusOffset = 0.25;
-			}
-
 			//calculate start and end screen coordinates of current RWR line
-			double startX = radius * startRadiusOffset * cos(radarAngle);
-			double startY = radius * startRadiusOffset * sin(radarAngle);
+			double startX = radius * 0.25 * cos(radarAngle);
+			double startY = radius * 0.25 * sin(radarAngle);
 			double endX = radius * 0.85 * cos(radarAngle);
 			double endY = radius * 0.85 * sin(radarAngle);
 
 			lineVtxBuf.Add<double>(startX, startY, zPlane);
-			lineColBuf.Add(currColor);
+			lineColBuf.Add(hudCol);
 			lineVtxBuf.Add<double>(endX, endY, zPlane);
-			lineColBuf.Add(currColor);
+			lineColBuf.Add(hudCol);
 
 			//determine RWR identifier based on aircraft category
 			std::string idString = "";
@@ -2006,7 +1985,7 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			YsMatrix4x4 tfm;
 			tfm.Translate(fontX - fontWidth / 2.0, fontY, zPlane);
 			tfm.Scale(fontWidth, fontHeight, 1.0);
-			FsAddWireFontVertexBuffer(lineVtxBuf, lineColBuf, triVtxBuf, triColBuf, tfm, idString.c_str(), currColor);
+			FsAddWireFontVertexBuffer(lineVtxBuf, lineColBuf, triVtxBuf, triColBuf, tfm, idString.c_str(), hudCol);
 			numThreatsDrawn++;
 		}
 	}
@@ -2017,10 +1996,12 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 	{
 		YsArray <int, 64> loading;
 		currGround->Prop().GetWeaponConfig(loading);
+		bool isLocking = currGround->Prop().GetAirTargetKey() == FsExistence::GetSearchKey(withRespectTo);
 		if (currGround->IsAlive() == YSTRUE 
 			&& currGround->Prop().IsNonGameObject() != YSTRUE
 			&& (currGround->GetPosition() - withRespectTo->GetPosition()).GetSquareLength() <= searchRadius * searchRadius
-			&& (loading.IsIncluded(FSWEAPON_AIM9) || loading.IsIncluded(FSWEAPON_AIM9X) || loading.IsIncluded(FSWEAPON_AIM120) || loading.IsIncluded(FSWEAPON_GUN)))
+			&& (loading.IsIncluded(FSWEAPON_AIM9) || loading.IsIncluded(FSWEAPON_AIM9X) || loading.IsIncluded(FSWEAPON_AIM120) || loading.IsIncluded(FSWEAPON_GUN))
+			&& isLocking)
 		{
 			YsVec3 relPosition;
 			YsVec2 prj;
@@ -2031,8 +2012,8 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			double radarAngle = atan2(relPosition.z(), relPosition.x());
 
 			//calculate start and end screen coordinates of current RWR line
-			double startX = radius * 0.05 * cos(radarAngle);
-			double startY = radius * 0.05 * sin(radarAngle);
+			double startX = radius * 0.25 * cos(radarAngle);
+			double startY = radius * 0.25 * sin(radarAngle);
 			double endX = radius * 0.85 * cos(radarAngle);
 			double endY = radius * 0.85 * sin(radarAngle);
 

--- a/src/core/fshud2.cpp
+++ b/src/core/fshud2.cpp
@@ -1888,20 +1888,30 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 					default:
 						idString = "U";
 						break;
+
 					case FSAC_NORMAL:
 						idString = "N";
+						break;
+
 					case FSAC_AEROBATIC:
 					case FSAC_FIGHTER:
 					case FSAC_WW2FIGHTER:
 						idString = "F";
+						break;
+
 					case FSAC_ATTACKER:
 					case FSAC_WW2ATTACKER:
 						idString = "A";
+						break;
+
 					case FSAC_HEAVYBOMBER:
 					case FSAC_WW2BOMBER:
 						idString = "B";
+						break;
+
 					case FSAC_UTILITY:
 						idString = "C";
+						break;
 				}
 
 				double fontX = radius * cos(radarAngle);

--- a/src/core/fshud2.cpp
+++ b/src/core/fshud2.cpp
@@ -1857,23 +1857,36 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			&& currAir->GetPosition().y() > altLimit
 			&& (currAir->GetPosition() - withRespectTo->GetPosition()).GetSquareLengthXZ() <= searchRadius * searchRadius)
 		{
+			//if the plane is locked onto us, draw in yellow
+			YsColor currColor;
+			if (currAir->Prop().GetAirTargetKey() == FsExistence::GetSearchKey(withRespectTo))
+			{
+				currColor = YsYellow();
+			}
+			else
+			{
+				currColor = hudCol;
+			}
+
 			//get relative position of current aircraft
 			YsVec3 relPosition;
 			ref.MulInverse(relPosition, currAir->Prop().GetPosition(), 1.0);
 
+			//calculate relative angle in XZ plane
 			double radarAngle = atan2(relPosition.z(), relPosition.x());
-			printf("%lf\n", YsRadToDeg(radarAngle));
 
+			//calculate start and end screen coordinates of current RWR line
 			double startX = radius * 0.25 * cos(radarAngle);
 			double startY = radius * 0.25 * sin(radarAngle);
 			double endX = radius * 0.85 * cos(radarAngle);
 			double endY = radius * 0.85 * sin(radarAngle);
 
 			lineVtxBuf.Add<double>(startX, startY, zPlane);
-			lineColBuf.Add(hudCol);
+			lineColBuf.Add(currColor);
 			lineVtxBuf.Add<double>(endX, endY, zPlane);
-			lineColBuf.Add(hudCol);
+			lineColBuf.Add(currColor);
 
+			//determine RWR identifier based on aircraft category
 			std::string idString = "";
 			switch (currAir->Prop().GetAirplaneCategory())
 			{
@@ -1907,12 +1920,13 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 					break;
 			}
 
+			//determine position of identifier letter and draw
 			double fontX = radius * cos(radarAngle);
 			double fontY = radius * sin(radarAngle);
 			YsMatrix4x4 tfm;
 			tfm.Translate(fontX - fontWidth / 2.0, fontY, zPlane);
 			tfm.Scale(fontWidth, fontHeight, 1.0);
-			FsAddWireFontVertexBuffer(lineVtxBuf, lineColBuf, triVtxBuf, triColBuf, tfm, idString.c_str(), hudCol);
+			FsAddWireFontVertexBuffer(lineVtxBuf, lineColBuf, triVtxBuf, triColBuf, tfm, idString.c_str(), currColor);
 		}
 	}
 }

--- a/src/core/fshud2.cpp
+++ b/src/core/fshud2.cpp
@@ -1857,9 +1857,12 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			&& currAir->GetPosition().y() > altLimit
 			&& (currAir->GetPosition() - withRespectTo->GetPosition()).GetSquareLengthXZ() <= searchRadius * searchRadius)
 		{
+			//check if current aircraft is locking onto us
+			bool isLocking = currAir->Prop().GetAirTargetKey() == FsExistence::GetSearchKey(withRespectTo);
+
 			//if the plane is locked onto us, draw in yellow
 			YsColor currColor;
-			if (currAir->Prop().GetAirTargetKey() == FsExistence::GetSearchKey(withRespectTo))
+			if (isLocking)
 			{
 				currColor = YsYellow();
 			}
@@ -1875,9 +1878,20 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 			//calculate relative angle in XZ plane
 			double radarAngle = atan2(relPosition.z(), relPosition.x());
 
+			//draw a longer RWR line marker if locking 
+			double startRadiusOffset;
+			if (isLocking)
+			{
+				startRadiusOffset = 0.05;
+			}
+			else
+			{
+				startRadiusOffset = 0.25;
+			}
+
 			//calculate start and end screen coordinates of current RWR line
-			double startX = radius * 0.25 * cos(radarAngle);
-			double startY = radius * 0.25 * sin(radarAngle);
+			double startX = radius * startRadiusOffset * cos(radarAngle);
+			double startY = radius * startRadiusOffset * sin(radarAngle);
 			double endX = radius * 0.85 * cos(radarAngle);
 			double endY = radius * 0.85 * sin(radarAngle);
 

--- a/src/core/fshud2.cpp
+++ b/src/core/fshud2.cpp
@@ -1833,16 +1833,8 @@ void FsHud2::DrawNav(
 	    selected,inop);
 }
 
-void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo, const double& airAltLimit, const double& x0, const double& y0, const double& radius) 
+void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo, const double& airAltLimit, const double& maxRadarRange, const double& x0, const double& y0, const double& radius)
 {
-	//for (int i = 0; i < 90; i += 15)
-	//{
-	//	double currX = radius * cos(YsDegToRad(i));
-	//	double currY = radius * sin(YsDegToRad(i));
-	//	lineVtxBuf.Add<double>(currX, currY, zPlane);
-	//	lineColBuf.Add(hudCol);
-	//}
-
 	YsAtt3 attH;
 	attH = withRespectTo->GetAttitude();
 	attH.SetP(0.0);
@@ -1855,72 +1847,72 @@ void FsHud2::DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo
 	double fontWidth = 0.02;
 	double fontHeight = 0.03;
 
+	double searchRadius = maxRadarRange / 2.0;
 	FsAirplane* currAir = NULL;
 	while ((currAir = sim->FindNextAirplane(currAir)) != NULL)
 	{
-		if (currAir != withRespectTo && currAir->IsAlive() == YSTRUE)
+		double altLimit = airAltLimit + 1000.0 * (1.0 - currAir->Prop().GetRadarCrossSection());
+		if (currAir != withRespectTo 
+			&& currAir->IsAlive() == YSTRUE 
+			&& currAir->GetPosition().y() > altLimit
+			&& (currAir->GetPosition() - withRespectTo->GetPosition()).GetSquareLengthXZ() <= searchRadius * searchRadius)
 		{
-			double altLimit = airAltLimit + 1000.0 * (1.0 - currAir->Prop().GetRadarCrossSection());
-			if (currAir->GetPosition().y() > altLimit)
+			//get relative position of current aircraft
+			YsVec3 relPosition;
+			ref.MulInverse(relPosition, currAir->Prop().GetPosition(), 1.0);
+
+			double radarAngle = atan2(relPosition.z(), relPosition.x());
+			printf("%lf\n", YsRadToDeg(radarAngle));
+
+			double startX = radius * 0.25 * cos(radarAngle);
+			double startY = radius * 0.25 * sin(radarAngle);
+			double endX = radius * 0.85 * cos(radarAngle);
+			double endY = radius * 0.85 * sin(radarAngle);
+
+			lineVtxBuf.Add<double>(startX, startY, zPlane);
+			lineColBuf.Add(hudCol);
+			lineVtxBuf.Add<double>(endX, endY, zPlane);
+			lineColBuf.Add(hudCol);
+
+			std::string idString = "";
+			switch (currAir->Prop().GetAirplaneCategory())
 			{
-				//get relative position of current aircraft
-				YsVec3 relPosition;
-				ref.MulInverse(relPosition, currAir->Prop().GetPosition(), 1.0);
+				case FSAC_UNKNOWN:
+				default:
+					idString = "U";
+					break;
 
-				//double radarAngle = atan2( sqrt(relPosition.x() * relPosition.x() + relPosition.y() * relPosition.y()), YsAbs(relPosition.z()) );
-				double radarAngle = atan2(relPosition.z(), relPosition.x());
-				printf("%lf\n", YsRadToDeg(radarAngle));
+				case FSAC_NORMAL:
+					idString = "N";
+					break;
 
-				double startX = radius * 0.25 * cos(radarAngle);
-				double startY = radius * 0.25 * sin(radarAngle);
-				double endX = radius * 0.85 * cos(radarAngle);
-				double endY = radius * 0.85 * sin(radarAngle);
+				case FSAC_AEROBATIC:
+				case FSAC_FIGHTER:
+				case FSAC_WW2FIGHTER:
+					idString = "F";
+					break;
 
-				lineVtxBuf.Add<double>(startX, startY, zPlane);
-				lineColBuf.Add(hudCol);
-				lineVtxBuf.Add<double>(endX, endY, zPlane);
-				lineColBuf.Add(hudCol);
+				case FSAC_ATTACKER:
+				case FSAC_WW2ATTACKER:
+					idString = "A";
+					break;
 
-				std::string idString = "";
-				switch (currAir->Prop().GetAirplaneCategory())
-				{
-					case FSAC_UNKNOWN:
-					default:
-						idString = "U";
-						break;
+				case FSAC_HEAVYBOMBER:
+				case FSAC_WW2BOMBER:
+					idString = "B";
+					break;
 
-					case FSAC_NORMAL:
-						idString = "N";
-						break;
-
-					case FSAC_AEROBATIC:
-					case FSAC_FIGHTER:
-					case FSAC_WW2FIGHTER:
-						idString = "F";
-						break;
-
-					case FSAC_ATTACKER:
-					case FSAC_WW2ATTACKER:
-						idString = "A";
-						break;
-
-					case FSAC_HEAVYBOMBER:
-					case FSAC_WW2BOMBER:
-						idString = "B";
-						break;
-
-					case FSAC_UTILITY:
-						idString = "C";
-						break;
-				}
-
-				double fontX = radius * cos(radarAngle);
-				double fontY = radius * sin(radarAngle);
-				YsMatrix4x4 tfm;
-				tfm.Translate(fontX - fontWidth / 2.0, fontY, zPlane);
-				tfm.Scale(fontWidth, fontHeight, 1.0);
-				FsAddWireFontVertexBuffer(lineVtxBuf, lineColBuf, triVtxBuf, triColBuf, tfm, idString.c_str(), hudCol);
+				case FSAC_UTILITY:
+					idString = "C";
+					break;
 			}
+
+			double fontX = radius * cos(radarAngle);
+			double fontY = radius * sin(radarAngle);
+			YsMatrix4x4 tfm;
+			tfm.Translate(fontX - fontWidth / 2.0, fontY, zPlane);
+			tfm.Scale(fontWidth, fontHeight, 1.0);
+			FsAddWireFontVertexBuffer(lineVtxBuf, lineColBuf, triVtxBuf, triColBuf, tfm, idString.c_str(), hudCol);
 		}
 	}
 }

--- a/src/core/fshud2.h
+++ b/src/core/fshud2.h
@@ -3,6 +3,8 @@
 /* { */
 
 #include <ysglcpp.h>
+#include "fsexistence.h"
+#include "fssimulation.h"
 
 class FsHud2
 {
@@ -96,6 +98,8 @@ public:
 	void DrawVelocityVectorIndicator(const YsVec3 &viewPos,const YsAtt3 &viewAtt,const YsVec3 &vel);
 
 	void DrawTurnAndSlipIndicator(const double cx,const double cy,const double rad,const double ssa,const double turnRate);
+
+	void DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo, const double& airAltLimit, const double& x0, const double& y0, const double& radius);
 };
 
 /* } */

--- a/src/core/fshud2.h
+++ b/src/core/fshud2.h
@@ -99,7 +99,7 @@ public:
 
 	void DrawTurnAndSlipIndicator(const double cx,const double cy,const double rad,const double ssa,const double turnRate);
 
-	void DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo, const double& airAltLimit, const double& maxRadarRange, const double& x0, const double& y0, const double& radius);
+	void DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo, const double& airAltLimit, const double& maxRadarRange, const double& x0, const double& y0, const double& radius, const int& maxNumThreatsToDraw = 8);
 };
 
 /* } */

--- a/src/core/fshud2.h
+++ b/src/core/fshud2.h
@@ -99,7 +99,7 @@ public:
 
 	void DrawTurnAndSlipIndicator(const double cx,const double cy,const double rad,const double ssa,const double turnRate);
 
-	void DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo, const double& airAltLimit, const double& x0, const double& y0, const double& radius);
+	void DrawRWRHUD(const FsSimulation* sim, const FsAirplane* withRespectTo, const double& airAltLimit, const double& maxRadarRange, const double& x0, const double& y0, const double& radius);
 };
 
 /* } */

--- a/src/core/fsradar.cpp
+++ b/src/core/fsradar.cpp
@@ -325,7 +325,7 @@ void FsHorizontalRadar::DrawCircular(const FsSimulation* sim, int x, int y, int 
 	//draw radar range string
 	char str[256];
 	sprintf(str, "%d NM", int(rangeInX));
-	FsDrawString(x - radius, y + radius, str, YsGreen());
+	FsDrawString(x - radius * 0.9, y - radius * 0.9, str, YsGreen());
 
 	//draw radar circle
 	FsDrawCircle(x, y, radius, YsGreen(), YSFALSE);

--- a/src/core/fsradar.cpp
+++ b/src/core/fsradar.cpp
@@ -477,20 +477,24 @@ void FsHorizontalRadar::DrawCircular(const FsSimulation* sim, int x, int y, int 
 					}
 
 					//draw rectangle for each plane
-					x = (int)prj1.x();
-					y = (int)prj1.y();
-					FsDrawDiamond(x, y, 5, col, YSFALSE);
+					FsDrawDiamond((int)prj1.x(), (int)prj1.y(), 5, col, YSFALSE);
 
 					//draw heading line for each plane (normalized and scaled velocity vector)
 					if (IsInsideCircle(prj2, YsVec2(x, y), radius) == YSTRUE)
 					{
-						FsDrawLine(x, y, (int)prj2.x(), (int)prj2.y(), col);
+						FsDrawLine((int)prj1.x(), (int)prj1.y(), (int)prj2.x(), (int)prj2.y(), col);
 					}
 
 					//if the plane is locked onto us, draw a yellow line to indicate
 					if (air->Prop().GetAirTargetKey() == FsExistence::GetSearchKey(&withRespectTo))
 					{
 						FsDrawLine((int)wc.x(), (int)wc.y(), (int)prj1.x(), (int)prj1.y(), YsYellow());
+					}
+
+					//if we're locked onto this plane, draw a green line to indicate
+					if (withRespectTo.Prop().GetAirTargetKey() == FsExistence::GetSearchKey(air))
+					{
+						FsDrawLine((int)wc.x(), (int)wc.y(), (int)prj1.x(), (int)prj1.y(), YsGreen());
 					}
 				}
 			}
@@ -541,7 +545,7 @@ void FsHorizontalRadar::DrawCircular(const FsSimulation* sim, int x, int y, int 
 YSBOOL FsHorizontalRadar::IsInsideCircle(YsVec2 point, YsVec2 circleCenter, int radius)
 {
 	point -= circleCenter;
-	if (point.GetLength() > radius)
+	if (point.GetSquareLength() > radius * radius)
 	{
 		return YSFALSE;
 	}

--- a/src/core/fsradar.cpp
+++ b/src/core/fsradar.cpp
@@ -205,10 +205,10 @@ void FsHorizontalRadar::DrawBasic(
 				ref.MulInverse(pos,air->GetPosition(),1.0);
 				ref.MulInverse(vel,vel,0.0);
 
-				//scale velocity by 8
+				//scale velocity by 12
 				if(vel.Normalize()==YSOK)
 				{
-					vel*=8.0;
+					vel*=12.0;
 				}
 
 				//scale position to radar scale
@@ -240,7 +240,7 @@ void FsHorizontalRadar::DrawBasic(
 					//draw rectangle for each plane
 					x=(int)prj1.x();
 					y=(int)prj1.y();
-					FsDrawRect(x-mkSize+1,y-mkSize+1,x+mkSize-1,y+mkSize-1,col,YSTRUE);
+					FsDrawDiamond(x, y, 5, col, YSFALSE);
 
 					//draw heading line for each plane (normalized and scaled velocity vector)
 					if(YsCheckInsideBoundingBox2(prj2,w1,w2)==YSTRUE)

--- a/src/core/fsradar.cpp
+++ b/src/core/fsradar.cpp
@@ -66,11 +66,11 @@ void FsHorizontalRadar::Draw(
 			const int y =(int)wc.y();
 			int xx=(int)wr.x();
 			int yy=(int)wr.y();
-			FsDrawLine(x,y,xx,yy,YsGreen());
+			FsDrawLine(x - 10,y - 10,xx,yy,YsGreen());
 			wr.Set(wc.x()+dx,w1.y());
 			xx=(int)wr.x();
 			yy=(int)wr.y();
-			FsDrawLine(x,y,xx,yy,YsGreen());
+			FsDrawLine(x + 10,y - 10,xx,yy,YsGreen());
 		}
 		break;
 	case 2:
@@ -140,10 +140,9 @@ void FsHorizontalRadar::DrawBasic(
 
 	x=(int)wc.x();
 	y=(int)wc.y();
-	FsDrawLine(x-5,y  ,x+5,y  ,YsGreen());
-	FsDrawPoint(x+5,y,YsGreen());
-	FsDrawLine(x  ,y-5,x  ,y+5,YsGreen());
-	FsDrawPoint(x,y+5,YsGreen());
+	FsDrawLine(x - 6, y - 5, x + 6, y - 5,YsGreen());
+	FsDrawLine(x  ,y-8,x  ,y+8,YsGreen());
+	FsDrawLine(x - 4, y + 5, x + 4, y + 5, YsGreen());
 
 
 	const FsGround *gnd;

--- a/src/core/fsradar.cpp
+++ b/src/core/fsradar.cpp
@@ -292,7 +292,8 @@ void FsHorizontalRadar::DrawBasic(
 
 			if(YsCheckInsideBoundingBox2(prj,w1,w2)==YSTRUE)
 			{
-				FsDrawPoint2Pix((int)prj.x(),(int)prj.y(),col);
+				//FsDrawPoint2Pix((int)prj.x(),(int)prj.y(),col);
+				FsDrawCircle((int)prj.x(), (int)prj.y(), mkSize, col, YSTRUE);
 			}
 		}
 	}

--- a/src/core/fsradar.cpp
+++ b/src/core/fsradar.cpp
@@ -266,13 +266,9 @@ void FsHorizontalRadar::DrawBasic(
 	{
 		if(wpn->lifeRemain>YsTolerance && wpn->timeRemain>YsTolerance)
 		{
-			if(wpn->type==FSWEAPON_AIM9 || wpn->type==FSWEAPON_AIM120)
+			if(wpn->type==FSWEAPON_AIM9 || wpn->type==FSWEAPON_AIM120 || wpn->type == FSWEAPON_AIM9X)
 			{
 				col=YsRed();
-			}
-			else if(wpn->type==FSWEAPON_AIM9X)
-			{
-				col=YsBlue();
 			}
 			else if(wpn->type==FSWEAPON_AGM65 || wpn->type==FSWEAPON_ROCKET)
 			{

--- a/src/core/fsradar.h
+++ b/src/core/fsradar.h
@@ -15,6 +15,10 @@ public:
 	    const class FsSimulation *sim,int x1,int y1,int x2,int y2,const double &rangeInX,
 	    const class FsExistence &withRespectTo,const YsVec3 &pos,const YsAtt3 &att,
 	    int mode,const double &airAltLimit) const;
+
+	void DrawCircular(const class FsSimulation* sim, int x, int y, int radius, const double &rangeInX, const class FsAirplane& withRespectTo, int mode, const double& airAltLimit);
+private:
+	YSBOOL IsInsideCircle(YsVec2 point, YsVec2 circleCenter, int radius);
 };
 
 

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -8297,7 +8297,7 @@ void FsSimulation::SimDrawHud3d(const YsVec3 &fakeViewPos,const YsAtt3 &instView
 
 			if (YsEqual(radarRange, 0.0) != YSTRUE)
 			{
-				hud2->DrawRWRHUD(this, GetPlayerAirplane(), cfgPtr->radarAltitudeLimit, 0.0, 0.0, 0.3);
+				hud2->DrawRWRHUD(this, GetPlayerAirplane(), cfgPtr->radarAltitudeLimit, 0.0, 0.0, 0.4);
 			}
 		}
 		hud2->EndDrawHud();

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -8021,12 +8021,12 @@ void FsSimulation::SimDrawRadar(const ActualViewMode &actualViewMode) const
 			int wid,hei;
 			FsGetWindowSize(wid,hei);
 
-			long radarSize=wid/5;
+			long radarSize = wid / 5;
 
-			long x1=wid * 3 / 4 - radarSize;
-			long y1=10;
-			long x2=wid * 3 / 4 + radarSize;
-			long y2=10+radarSize;
+			long x1 = wid - radarSize - 10;
+			long y1 = 10;
+			long x2 = wid - 10;
+			long y2 = 10 + radarSize;
 
 			switch(playerPlane->Prop().GetWeaponOfChoice())
 			{
@@ -8035,19 +8035,45 @@ void FsSimulation::SimDrawRadar(const ActualViewMode &actualViewMode) const
 			case FSWEAPON_AIM9:
 			case FSWEAPON_AIM9X:
 			case FSWEAPON_AIM120:
-				//radar.Draw(this,x1,y1,x2,y2,radarRange,*GetPlayerAirplane(),0,cfgPtr->radarAltitudeLimit);
-				radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 0, cfgPtr->radarAltitudeLimit);
+				if (cfgPtr->drawCircleRadar == YSTRUE)
+				{
+					radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 0, cfgPtr->radarAltitudeLimit);
+				}
+				else
+				{
+					radar.Draw(this,x1,y1,x2,y2,radarRange,*GetPlayerAirplane(),0,cfgPtr->radarAltitudeLimit);
+				}
 				break;
 			case FSWEAPON_AGM65:
-				//radar.Draw(this,x1,y1,x2,y2,radarRange,*GetPlayerAirplane(),1,cfgPtr->radarAltitudeLimit);
-				radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 1, cfgPtr->radarAltitudeLimit);
+				if (cfgPtr->drawCircleRadar == YSTRUE)
+				{
+					radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 1, cfgPtr->radarAltitudeLimit);
+				}
+				else
+				{
+					radar.Draw(this, x1, y1, x2, y2, radarRange, *GetPlayerAirplane(), 1, cfgPtr->radarAltitudeLimit);
+				}
 				break;
 			case FSWEAPON_BOMB:
 			case FSWEAPON_BOMB250:
-				radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 2, cfgPtr->radarAltitudeLimit);
+				if (cfgPtr->drawCircleRadar == YSTRUE)
+				{
+					radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 2, cfgPtr->radarAltitudeLimit);
+				}
+				else
+				{
+					radar.Draw(this, x1, y1, x2, y2, radarRange, *GetPlayerAirplane(), 2, cfgPtr->radarAltitudeLimit);
+				}
 				break;
 			case FSWEAPON_BOMB500HD:
-				radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 2, cfgPtr->radarAltitudeLimit);
+				if (cfgPtr->drawCircleRadar == YSTRUE)
+				{
+					radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 2, cfgPtr->radarAltitudeLimit);
+				}
+				else
+				{
+					radar.Draw(this, x1, y1, x2, y2, radarRange, *GetPlayerAirplane(), 2, cfgPtr->radarAltitudeLimit);
+				}
 				break;
 			}
 		}

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -8297,7 +8297,7 @@ void FsSimulation::SimDrawHud3d(const YsVec3 &fakeViewPos,const YsAtt3 &instView
 
 			if (YsEqual(radarRange, 0.0) != YSTRUE)
 			{
-				hud2->DrawRWRHUD(this, GetPlayerAirplane(), cfgPtr->radarAltitudeLimit, 0.0, 0.0, 0.4);
+				hud2->DrawRWRHUD(this, GetPlayerAirplane(), cfgPtr->radarAltitudeLimit, radarRange * 1852, 0.0, 0.0, 0.4);
 			}
 		}
 		hud2->EndDrawHud();

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -8023,9 +8023,9 @@ void FsSimulation::SimDrawRadar(const ActualViewMode &actualViewMode) const
 
 			long radarSize=wid/5;
 
-			long x1=wid-radarSize-10;
+			long x1=wid * 3 / 4 - radarSize;
 			long y1=10;
-			long x2=wid-10;
+			long x2=wid * 3 / 4 + radarSize;
 			long y2=10+radarSize;
 
 			switch(playerPlane->Prop().GetWeaponOfChoice())

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -8292,6 +8292,13 @@ void FsSimulation::SimDrawHud3d(const YsVec3 &fakeViewPos,const YsAtt3 &instView
 					   adf.IsInop());
 				}
 			}
+
+			double radarRange = playerPlane->Prop().GetCurrentRadarRange();
+
+			if (YsEqual(radarRange, 0.0) != YSTRUE)
+			{
+				hud2->DrawRWRHUD(this, GetPlayerAirplane(), cfgPtr->radarAltitudeLimit, 0.0, 0.0, 0.3);
+			}
 		}
 		hud2->EndDrawHud();
 		// HUD2 <<

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -8321,7 +8321,7 @@ void FsSimulation::SimDrawHud3d(const YsVec3 &fakeViewPos,const YsAtt3 &instView
 
 			double radarRange = playerPlane->Prop().GetCurrentRadarRange();
 
-			if (YsEqual(radarRange, 0.0) != YSTRUE)
+			if (YsEqual(radarRange, 0.0) != YSTRUE && cfgPtr->drawRWR == YSTRUE)
 			{
 				hud2->DrawRWRHUD(this, GetPlayerAirplane(), cfgPtr->radarAltitudeLimit, radarRange * 1852, 0.0, 0.0, 0.4);
 			}

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -8035,17 +8035,19 @@ void FsSimulation::SimDrawRadar(const ActualViewMode &actualViewMode) const
 			case FSWEAPON_AIM9:
 			case FSWEAPON_AIM9X:
 			case FSWEAPON_AIM120:
-				radar.Draw(this,x1,y1,x2,y2,radarRange,*GetPlayerAirplane(),0,cfgPtr->radarAltitudeLimit);
+				//radar.Draw(this,x1,y1,x2,y2,radarRange,*GetPlayerAirplane(),0,cfgPtr->radarAltitudeLimit);
+				radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 0, cfgPtr->radarAltitudeLimit);
 				break;
 			case FSWEAPON_AGM65:
-				radar.Draw(this,x1,y1,x2,y2,radarRange,*GetPlayerAirplane(),1,cfgPtr->radarAltitudeLimit);
+				//radar.Draw(this,x1,y1,x2,y2,radarRange,*GetPlayerAirplane(),1,cfgPtr->radarAltitudeLimit);
+				radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 1, cfgPtr->radarAltitudeLimit);
 				break;
 			case FSWEAPON_BOMB:
 			case FSWEAPON_BOMB250:
-				radar.Draw(this,x1,y1,x2,y2,radarRange,*GetPlayerAirplane(),2,cfgPtr->radarAltitudeLimit);
+				radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 2, cfgPtr->radarAltitudeLimit);
 				break;
 			case FSWEAPON_BOMB500HD:
-				radar.Draw(this,x1,y1,x2,y2,radarRange,*GetPlayerAirplane(),1,cfgPtr->radarAltitudeLimit);
+				radar.DrawCircular(this, (x1 + x2) / 2, (y1 + y2) / 2, radarSize / 2, radarRange, *GetPlayerAirplane(), 2, cfgPtr->radarAltitudeLimit);
 				break;
 			}
 		}

--- a/src/core/fssubmenu.cpp
+++ b/src/core/fssubmenu.cpp
@@ -529,6 +529,9 @@ void FsSubMenu::ProcessSubMenu(class FsSimulation *sim,class FsFlightConfig &cfg
 		case FSKEY_R:
 			YsFlip(cfg.drawCircleRadar);
 			break;
+		case FSKEY_Y:
+			YsFlip(cfg.drawRWR);
+			break;
 		}
 		break;
 	}
@@ -989,6 +992,18 @@ void FsSubMenu::Draw(const class FsSimulation *sim,class FsFlightConfig &cfg,int
 		default:
 		case YSFALSE:
 			FsDrawString(sx, sy, "R: Radar Display Style (Now: Square)", YsWhite());
+			break;
+		}
+		sy += fsAsciiRenderer.GetFontHeight();
+
+		switch (cfg.drawRWR)
+		{
+		case YSTRUE:
+			FsDrawString(sx, sy, "Y: Draw Radar Warning Receiver on HUD (Now: ON)", YsWhite());
+			break;
+		default:
+		case YSFALSE:
+			FsDrawString(sx, sy, "Y: Draw Radar Warning Receiver on HUD(Now : OFF)", YsWhite());
 			break;
 		}
 		sy += fsAsciiRenderer.GetFontHeight();

--- a/src/core/fssubmenu.cpp
+++ b/src/core/fssubmenu.cpp
@@ -526,6 +526,9 @@ void FsSubMenu::ProcessSubMenu(class FsSimulation *sim,class FsFlightConfig &cfg
 		case FSKEY_I:
 			YsFlip(cfg.showIAS);
 			break;
+		case FSKEY_R:
+			YsFlip(cfg.drawCircleRadar);
+			break;
 		}
 		break;
 	}
@@ -977,6 +980,18 @@ void FsSubMenu::Draw(const class FsSimulation *sim,class FsFlightConfig &cfg,int
 			break;
 		}
 		sy+=fsAsciiRenderer.GetFontHeight();
+
+		switch (cfg.drawCircleRadar)
+		{
+		case YSTRUE:
+			FsDrawString(sx, sy, "R: Radar Display Style (Now: Circle)", YsWhite());
+			break;
+		default:
+		case YSFALSE:
+			FsDrawString(sx, sy, "R: Radar Display Style (Now: Square)", YsWhite());
+			break;
+		}
+		sy += fsAsciiRenderer.GetFontHeight();
 
 		break;
 	case FSSUBMENU_GUNNER:


### PR DESCRIPTION
- Adds a RWR display on the HUD - this draws up to 8 threats which are targeting the aircraft in the following priority: missiles first, then aircraft, then ground vehicles. Missiles are drawn as red marks while locks are drawn as yellow marks. Only missiles and/or vehicles which are actively targeting the aircraft are drawn, currently (this behavior is subject to change if/when we overhaul the way radar is handled).
- Adds a circular radar as a toggle-able option.
- Changes to radar UI elements, aimed at increasing readability