### PR TITLE
Add upload-artifact job to CI pipeline

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: ys-build-windows
-        path: ./ci_windows/main/
+        path: ./ci_windows/main/Release
 
 
 

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -35,7 +35,6 @@ jobs:
       run: cmake --build . --config Release --parallel --target ysflight64_gl1 ysflight64_gl2 ysflight64_gl1demo ysflight64_gl2demo ysflight64_nownd
       # Cannot build ysflight64_d3d9 in github workflow because the virtual machine does not have DirectX9 libraries.
       working-directory: ./ci_windows
-    - name: upload build artifacts
     - uses: actions/upload-artifact@v3
       with:
         name: ys-build-windows
@@ -78,7 +77,6 @@ jobs:
     - name: build
       run: cmake --build . --config Release --parallel --target ysflight64_gl1 ysflight64_gl2 ysflight64_gl1demo ysflight64_gl2demo ysflight64_nownd
       working-directory: ./ci_ubuntu
-    - name: upload build artifacts
     - uses: actions/upload-artifact@v3
       with:
         name: ys-build-linux

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -35,6 +35,10 @@ jobs:
       run: cmake --build . --config Release --parallel --target ysflight64_gl1 ysflight64_gl2 ysflight64_gl1demo ysflight64_gl2demo ysflight64_nownd
       # Cannot build ysflight64_d3d9 in github workflow because the virtual machine does not have DirectX9 libraries.
       working-directory: ./ci_windows
+    - uses: actions/upload-artifact@v3
+      with:
+        name: upload-ys-artifacts
+        path: ./ci_windows/main/
 
 
 
@@ -73,4 +77,8 @@ jobs:
     - name: build
       run: cmake --build . --config Release --parallel --target ysflight64_gl1 ysflight64_gl2 ysflight64_gl1demo ysflight64_gl2demo ysflight64_nownd
       working-directory: ./ci_ubuntu
+    - uses: actions/upload-artifact@v3
+      with:
+        name: upload-ys-artifacts
+        path: ./ci_ubuntu/main/
 # MacOS was here, but Nodoka kicked it off a short pier.

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,13 +1,13 @@
 name: Continuous Integration
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
     tags-ignore:
       - 'v*' # Don't run if tagged as v*.
   pull_request:
     branches: [ master ]
-  workflow_dispatch
 
 jobs:
   build-windows:

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -35,9 +35,10 @@ jobs:
       run: cmake --build . --config Release --parallel --target ysflight64_gl1 ysflight64_gl2 ysflight64_gl1demo ysflight64_gl2demo ysflight64_nownd
       # Cannot build ysflight64_d3d9 in github workflow because the virtual machine does not have DirectX9 libraries.
       working-directory: ./ci_windows
+    - name: upload build artifacts
     - uses: actions/upload-artifact@v3
       with:
-        name: upload-ys-artifacts
+        name: ys-build-windows
         path: ./ci_windows/main/
 
 
@@ -77,8 +78,9 @@ jobs:
     - name: build
       run: cmake --build . --config Release --parallel --target ysflight64_gl1 ysflight64_gl2 ysflight64_gl1demo ysflight64_gl2demo ysflight64_nownd
       working-directory: ./ci_ubuntu
+    - name: upload build artifacts
     - uses: actions/upload-artifact@v3
       with:
-        name: upload-ys-artifacts
+        name: ys-build-linux
         path: ./ci_ubuntu/main/
 # MacOS was here, but Nodoka kicked it off a short pier.

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -7,6 +7,7 @@ on:
       - 'v*' # Don't run if tagged as v*.
   pull_request:
     branches: [ master ]
+  workflow_dispatch
 
 jobs:
   build-windows:


### PR DESCRIPTION
Addresses https://github.com/YSCEDC/YSCE/issues/49

- Adds `workflow_dispatch` trigger to the CI pipeline to allow it to be run manually (this is mainly for testing CI pipeline changes without kicking off master builds, and should be used sparingly to prevent using too much artifact storage)
- Adds `upload-artifact` step to the Windows and Linux build pipelines so that builds can be downloaded

