### PR TITLE
Implemented fix for receiving 2015v clients

### DIFF
--- a/src/core/fsnetwork.cpp
+++ b/src/core/fsnetwork.cpp
@@ -4342,15 +4342,18 @@ YSRESULT FsSocketServer::SendEnvironment(int clientId)
 
 YSRESULT FsSocketServer::SendLogOnComplete(int clientId)
 {
-	unsigned char dat[256],*ptr;
-	ptr=dat;
-	FsPushInt(ptr,FSNETCMD_LOGON);
+	if(user[clientId].version>20150425){
+		unsigned char dat[256],*ptr;
+		ptr=dat;
+		FsPushInt(ptr,FSNETCMD_LOGON);
 
-	SendPacket(clientId,ptr-dat,dat);
-	FlushSendQueue(clientId,FS_NETEMERGENCYTIMEOUT);
-	SendPacket(clientId,ptr-dat,dat);
-	FlushSendQueue(clientId,FS_NETEMERGENCYTIMEOUT);
-	SendPacket(clientId,ptr-dat,dat);
+		SendPacket(clientId,ptr-dat,dat);
+		FlushSendQueue(clientId,FS_NETEMERGENCYTIMEOUT);
+		SendPacket(clientId,ptr-dat,dat);
+		FlushSendQueue(clientId,FS_NETEMERGENCYTIMEOUT);
+		SendPacket(clientId,ptr-dat,dat);
+	}
+	
 	return YSOK;
 }
 


### PR DESCRIPTION
Fix for #51 - Does not send this message if connection is from a 2015 version of YSFLIGHT. Log on complete appears to be sent through combination of chat message and preparing simulation message in 2015 version.