### PR TITLE
toggle camera perspective center as config option

### DIFF
--- a/runtime/language/en.uitxt
+++ b/runtime/language/en.uitxt
@@ -230,6 +230,7 @@ $BGCOL 0
 +configdlg/autorudder                              #Rudder Auto Coordination
 +configdlg/precision                               #Precise Simulation
 +configdlg/showhudalways                           #Always Show HUD
++configdlg/centercameraperspective                 #Center Camera Perspective
 +configdlg/dontuseinstpanel                        #Do not use Instrument Panel
 +configdlg/showplayernamealways                    #Always Draw Player Name
 +configdlg/showjoystick                            #Draw Virtual Joystick

--- a/src/common/fstextresource.h
+++ b/src/common/fstextresource.h
@@ -256,6 +256,7 @@ inline const wchar_t *FsGetTextResource(const char *key,const wchar_t *alternati
 #define FSGUI_CFGDLG_AUTORUDDER                           FsGetTextResource("configdlg/autorudder",L"Rudder Auto Coordination")
 #define FSGUI_CFGDLG_PRECISION                            FsGetTextResource("configdlg/precision",L"Precise Simulation")
 #define FSGUI_CFGDLG_SHOWHUDALWAYS                        FsGetTextResource("configdlg/showhudalways",L"Always Show HUD")
+#define FSGUI_CFGDLG_CENTERCAMERAPERSPECTIVE              FsGetTextResource("configdlg/centercameraperspective",L"Center Camera Perspective")
 #define FSGUI_CFGDLG_NOINSTPANEL                          FsGetTextResource("configdlg/dontuseinstpanel",L"Do not use Instrument Panel")
 #define FSGUI_CFGDLG_SHOWNAMEALWAYS                       FsGetTextResource("configdlg/showplayernamealways",L"Always Draw Player Name")
 #define FSGUI_CFGDLG_SHOWJOYSTICK                         FsGetTextResource("configdlg/showjoystick",L"Draw Virtual Joystick")

--- a/src/config/fsconfig.cpp
+++ b/src/config/fsconfig.cpp
@@ -42,6 +42,7 @@ void FsFlightConfig::SetDefault(void)
 	drawTransparentSmoke=YSTRUE;
 	drawTransparentLater=YSTRUE;
 	drawCircleRadar = YSFALSE;
+	centerCameraPerspective = YSTRUE;
 	drawRWR = YSTRUE;
 	drawPlayerNameAlways=YSTRUE;
 	drawLightsInDaylight=YSTRUE;
@@ -229,6 +230,7 @@ const char *const FsFlightConfig::keyWordSource[]=
 	"CONSTWIND", // 2023/07/29
 
 	"CLOUDLAYER", // 2023/07/29
+	"CENTERCAM",  // 2023/08/15
 
 	NULL
 };
@@ -549,7 +551,8 @@ YSRESULT FsFlightConfig::SendCommand(const char cmd[])
 						
 					}
 				}
-				
+			case 64: // CENTERCAM
+				return FsGetBool(centerCameraPerspective, av[1]);
 			
 		}
 		}
@@ -646,6 +649,8 @@ YSRESULT FsFlightConfig::Save(const wchar_t fn[])
 		fprintf(fp,"DEFAIRPLN \"%s\"\n",defAirplane);
 
 		fprintf(fp,"HUDALWAYS %s\n",FsTrueFalseString(showHudAlways));
+
+		fprintf(fp, "CENTERCAM %s\n", FsTrueFalseString(centerCameraPerspective));
 
 		fprintf(fp,"JSCALIBRA %s\n",FsTrueFalseString(additionalCalibration));
 

--- a/src/config/fsconfig.h
+++ b/src/config/fsconfig.h
@@ -56,6 +56,7 @@ public:
 	YSBOOL drawTransparentLater;
 	YSBOOL drawRWR;
 	YSBOOL drawCircleRadar;
+	YSBOOL centerCameraPerspective;
 	YSBOOL useOpenGlListForCloud;
 	YSBOOL useOpenGlListForExplosion;
 	YSBOOL useOpenGlListForWeapon;

--- a/src/core/fsguiconfigdlg.cpp
+++ b/src/core/fsguiconfigdlg.cpp
@@ -216,24 +216,26 @@ void FsGuiConfigDialog::MakeDefaultsDialog(FsWorld *world,FsFlightConfig &cfg)
 
 void FsGuiConfigDialog::MakeGameDialog(FsWorld *,FsFlightConfig &)
 {
-	blackOutBtn            =AddTextButton(MkId("blackOut"),    FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_BLACKOUT       ,YSTRUE);
-	midAirCollisionBtn     =AddTextButton(MkId("midAirColl"),  FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_MIDAIR         ,YSFALSE);
-	noTailStrikeBtn        =AddTextButton(MkId("noTailStrike"),FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_NOTAILSTRIKE   ,YSTRUE);
-	canLandAnywhereBtn     =AddTextButton(MkId("landAnywhere"),FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_CANLANDANYWHERE,YSFALSE);
-	autoRudderBtn          =AddTextButton(MkId("autoRudder"),  FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_AUTORUDDER     ,YSTRUE);
-	preciseSimulationBtn   =AddTextButton(MkId("preciseSim"),  FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_PRECISION      ,YSFALSE);
-	alwaysShowHudBtn       =AddTextButton(MkId("alwaysHud"),   FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_SHOWHUDALWAYS  ,YSTRUE);
-	doNotUseInstPanelBtn   =AddTextButton(MkId("noInstPanel"), FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_NOINSTPANEL    ,YSFALSE);
+	blackOutBtn                = AddTextButton(MkId("blackOut"),    FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_BLACKOUT       ,YSTRUE);
+	midAirCollisionBtn         = AddTextButton(MkId("midAirColl"),  FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_MIDAIR         ,YSFALSE);
+	noTailStrikeBtn            = AddTextButton(MkId("noTailStrike"),FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_NOTAILSTRIKE   ,YSTRUE);
+	canLandAnywhereBtn         = AddTextButton(MkId("landAnywhere"),FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_CANLANDANYWHERE,YSFALSE);
+	autoRudderBtn              = AddTextButton(MkId("autoRudder"),  FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_AUTORUDDER     ,YSTRUE);
+	preciseSimulationBtn       = AddTextButton(MkId("preciseSim"),  FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_PRECISION      ,YSFALSE);
+	alwaysShowHudBtn		   = AddTextButton(MkId("alwaysHud"),   FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_SHOWHUDALWAYS  ,YSTRUE);
+	doNotUseInstPanelBtn       = AddTextButton(MkId("noInstPanel"), FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_NOINSTPANEL    ,YSFALSE);
 
-	simpleHudBtn           =AddTextButton(MkId("simpleHud"),FSKEY_NULL,FSGUI_RADIOBUTTON,FSGUI_CFGDLG_USESIMPLEHUD,YSTRUE);
-	threeDHudBtn           =AddTextButton(MkId("3dHud"),    FSKEY_NULL,FSGUI_RADIOBUTTON,FSGUI_CFGDLG_USE3DHUD,YSFALSE);
+	simpleHudBtn               = AddTextButton(MkId("simpleHud"),FSKEY_NULL,FSGUI_RADIOBUTTON,FSGUI_CFGDLG_USESIMPLEHUD,YSTRUE);
+	threeDHudBtn               = AddTextButton(MkId("3dHud"),    FSKEY_NULL,FSGUI_RADIOBUTTON,FSGUI_CFGDLG_USE3DHUD,YSFALSE);
 	FsGuiButton *hudTypeRadioButtonGroup[2]={simpleHudBtn,threeDHudBtn};
 	SetRadioButtonGroup(2,hudTypeRadioButtonGroup);
 
-	alwaysDrawPlayerNameBtn=AddTextButton(MkId("drawName"),    FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_SHOWNAMEALWAYS ,YSTRUE);
-	drawVirtualJoystickBtn =AddTextButton(MkId("drawJoystick"),FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_SHOWJOYSTICK   ,YSFALSE);
-	f8CameraDelayBtn       =AddTextButton(MkId("f8Delay"),     FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_F8CAMERADELAY  ,YSTRUE);
-	showIASBtn             =AddTextButton(MkId("showIAS"),     FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_SHOWIAS        ,YSFALSE);
+	alwaysDrawPlayerNameBtn = AddTextButton(MkId("drawName"),    FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_SHOWNAMEALWAYS ,YSTRUE);
+	drawVirtualJoystickBtn  = AddTextButton(MkId("drawJoystick"),FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_SHOWJOYSTICK   ,YSFALSE);
+	f8CameraDelayBtn        = AddTextButton(MkId("f8Delay"),     FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_F8CAMERADELAY  ,YSTRUE);
+	showIASBtn              = AddTextButton(MkId("showIAS"),     FSKEY_NULL,FSGUI_CHECKBOX,FSGUI_CFGDLG_SHOWIAS        ,YSFALSE);
+	centerCameraPerspectiveBtn = AddTextButton(MkId("centerCameraPerspective"), FSKEY_NULL, FSGUI_CHECKBOX, FSGUI_CFGDLG_CENTERCAMERAPERSPECTIVE, YSTRUE);
+
 
 	YsArray <YsArray <FsGuiDialogItem *> > dlgItemMatrix;
 	dlgItemMatrix.Increment();
@@ -257,6 +259,8 @@ void FsGuiConfigDialog::MakeGameDialog(FsWorld *,FsFlightConfig &)
 	dlgItemMatrix.Increment();
 	dlgItemMatrix.GetEnd().Append(f8CameraDelayBtn);
 	dlgItemMatrix.GetEnd().Append(showIASBtn);
+	dlgItemMatrix.Increment();
+	dlgItemMatrix.GetEnd().Append(centerCameraPerspectiveBtn);
 	AlignLeftMiddle(dlgItemMatrix);
 
 	radarAltLimitTxt       =AddTextBox(12,FSKEY_NULL,FSGUI_CFGDLG_MINRADARALT,"",8,YSTRUE);
@@ -432,6 +436,7 @@ void FsGuiConfigDialog::InitializeDialog(FsWorld *,FsFlightConfig &cfg)
 	autoRudderBtn->SetCheck(cfg.autoCoordination);
 	preciseSimulationBtn->SetCheck(cfg.accurateTime);
 	alwaysShowHudBtn->SetCheck(cfg.showHudAlways);
+	centerCameraPerspectiveBtn->SetCheck(cfg.centerCameraPerspective);
 	doNotUseInstPanelBtn->SetCheck(cfg.useHudAlways);
 
 	if(YSTRUE==cfg.useSimpleHud)
@@ -607,6 +612,7 @@ void FsGuiConfigDialog::RetrieveConfig(FsFlightConfig &cfg)
 	cfg.canLandAnywhere=canLandAnywhereBtn->GetCheck();
 	cfg.autoCoordination=autoRudderBtn->GetCheck();
 	cfg.accurateTime=preciseSimulationBtn->GetCheck();
+	cfg.centerCameraPerspective = centerCameraPerspectiveBtn->GetCheck();
 	cfg.showHudAlways=alwaysShowHudBtn->GetCheck();
 	cfg.useHudAlways=doNotUseInstPanelBtn->GetCheck();
 	cfg.useSimpleHud=simpleHudBtn->GetCheck();

--- a/src/core/fsguiconfigdlg.h
+++ b/src/core/fsguiconfigdlg.h
@@ -29,6 +29,7 @@ public:
 
 	FsGuiButton *blackOutBtn,*midAirCollisionBtn,*noTailStrikeBtn,*canLandAnywhereBtn;
 	FsGuiButton *autoRudderBtn,*preciseSimulationBtn,*alwaysShowHudBtn,*doNotUseInstPanelBtn;
+	FsGuiButton* centerCameraPerspectiveBtn;
 	FsGuiButton *showIASBtn;
 	FsGuiButton *simpleHudBtn,*threeDHudBtn;
 	FsGuiButton *alwaysDrawPlayerNameBtn,*drawVirtualJoystickBtn,*f8CameraDelayBtn;

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -6905,7 +6905,15 @@ FsProjection FsSimulation::SimDrawPrepare(const ActualViewMode &actualViewMode) 
 
 	sizx=hei*4/3;
 	sizy=hei;
-	hud->SetAreaByCenter(wid/2,hei*2/3,sizx*2/3,sizy*2/3);
+	if (cfgPtr->centerCameraPerspective == YSFALSE)
+	{
+		hud->SetAreaByCenter(wid / 2, hei * 2 / 3, sizx * 2 / 3, sizy * 2 / 3);
+	}
+	else
+	{
+		hud->SetAreaByCenter(wid / 2, hei / 2, sizx * 2 / 3, sizy * 2 / 3);
+	}
+
 
 #ifdef CRASHINVESTIGATION_SIMDRAWSCREEN
 	printf("SIMDRAW-2.8\n");

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -9672,13 +9672,8 @@ void FsSimulation::GetProjection(FsProjection &prj,const ActualViewMode &actualV
 	FsGetDrawingAreaSize(wid,hei);
 
 	playerPlane=GetPlayerAirplane();
-
-	if(0!=(GetInstrumentDrawSwitch(actualViewMode)&FSISS_2DHUD))
-	{
-		prj.cx=wid/2;
-		prj.cy=hei*2/3;
-	}
-	else if(FSCOCKPITVIEW==actualViewMode.actualViewMode && NULL!=playerPlane)
+	
+	if(cfgPtr->centerCameraPerspective == YSFALSE && NULL!=playerPlane)
 	{
 		const YsVec2 scrnCen=playerPlane->Prop().GetScreenCenter();
 		prj.cx=(int)((double)wid*(1.0+scrnCen.x())/2.0);

--- a/src/core/fssubmenu.cpp
+++ b/src/core/fssubmenu.cpp
@@ -532,6 +532,9 @@ void FsSubMenu::ProcessSubMenu(class FsSimulation *sim,class FsFlightConfig &cfg
 		case FSKEY_Y:
 			YsFlip(cfg.drawRWR);
 			break;
+		case FSKEY_O:
+			YsFlip(cfg.centerCameraPerspective);
+			break;
 		}
 		break;
 	}
@@ -1004,6 +1007,18 @@ void FsSubMenu::Draw(const class FsSimulation *sim,class FsFlightConfig &cfg,int
 		default:
 		case YSFALSE:
 			FsDrawString(sx, sy, "Y: Draw Radar Warning Receiver on HUD(Now : OFF)", YsWhite());
+			break;
+		}
+		sy += fsAsciiRenderer.GetFontHeight();
+
+		switch (cfg.centerCameraPerspective)
+		{
+		case YSTRUE:
+			FsDrawString(sx, sy, "O: Center Camera Perspective (Now: TRUE)", YsWhite());
+			break;
+		default:
+		case YSFALSE:
+			FsDrawString(sx, sy, "O: Center Camera Perspective (Now: FALSE)", YsWhite());
 			break;
 		}
 		sy += fsAsciiRenderer.GetFontHeight();


### PR DESCRIPTION
Currently, the camera perspective center shifts based on the camera mode (in first-person view, the center is biased towards the bottom of the screen, and it is properly centered otherwise). 

This PR separates this functionality into its own dedicated setting which can be toggled via the options menu and the ingame flight config menu. 