### PR TITLE
YSCE Day/Night cycle

### DIFF
--- a/src/core/fsnetwork.h
+++ b/src/core/fsnetwork.h
@@ -187,6 +187,7 @@ public:
 	YsArray <unsigned int> gndToSend,airToSend;
 	YSBOOL useMissileReadBack,useUnguidedWeaponReadBack,controlShowUserNameReadBack;
 	YSBOOL environmentReadBack,preparationReadBack;
+	YSBOOL usingYSCE;
 
 	YsArray <unsigned int> gndRmvToSend,airRmvToSend;
 	int joinSequence;  // 0:Not in process  1:Waiting for Airplane Read Back  2:Waiting for SetPlayer Read Back
@@ -253,7 +254,6 @@ enum FSNET_CONSOLE_COMMAND
 	FSNCC_SVR_STARTENDURANCEMODE_JET,
 	FSNCC_SVR_STARTENDURANCEMODE_WW2,
 	FSNCC_SVR_STARTCLOSEAIRSUPPORTMISSION,
-	FSNCC_SVR_SETDAY,
 	FSNCC_SVR_TERMINATEMISSION,
 	FSNCC_SVR_REVIVEGROUND,
 
@@ -381,7 +381,6 @@ public:
 	YSRESULT BroadcastGroundColor(YsColor col);
 	YSRESULT BroadcastFogColor(YsColor col);
 	YSRESULT BroadcastForceJoin(void);
-	YSRESULT BroadcastEnvironment(void);
 
 	YSRESULT RectifyIllegalMissiles(void);
 
@@ -535,6 +534,7 @@ public:
 	YSBOOL connectionClosedByServer; // Will be set YSTRUE if the connection was closed from the server side.
 	int lastErrorFromServer;
 	unsigned int reportedServerVersion;
+	YSBOOL ysceServer;
 
 	FsSocketClient(const char username[],const int port,class FsSimulation *associatedSimulation,class FsNetConfig *cfg);
 
@@ -610,7 +610,7 @@ public:
 	YSRESULT ReceiveGetDamage(unsigned char dat[]);
 	YSRESULT ReceiveSetTestAutopilot(unsigned char dat[]);
 	YSRESULT ReceiveAssignSideWindow(unsigned char dat[]);
-	YSRESULT ReceiveVersionNotify(unsigned char dat[]);
+	YSRESULT ReceiveVersionNotify(unsigned int packetLength,unsigned char dat[]);
 	YSRESULT ReceiveAirCmd(unsigned char dat[]);
 	YSRESULT ReceiveGndCmd(unsigned char dat[]);
 	YSRESULT ReceiveTextMessage(unsigned char dat[]);

--- a/src/core/fssimulation.h
+++ b/src/core/fssimulation.h
@@ -289,8 +289,17 @@ protected:
 
 	FSENVIRONMENT env;
 	YsColor fogColor;
-	YsColor skyColor,gndColor;
+	YsColor skyColor,gndColor; //These are the original sky/ground colours, set by the field. We won't modify them too much.
 	YSBOOL gndSpecular;
+
+	YsVec3 &lightPositionVector = YsVec3(-1.0, 1, 0.0);
+	YsColor dayColour = YsColor(1,1,1);
+	YsColor nightColour = YsColor(0.1,0.1,0.1);
+	YsColor sunriseColour = YsColor(1,0.5,0);
+	mutable int dayLength = 60;
+	mutable double daycycle = YsPi;
+	mutable double lightIntensity = 1;
+	mutable YsColor lightColour = YsColor(1,1,1);
 
 	class ActualViewMode
 	{
@@ -477,6 +486,11 @@ public:
 	void SetEnvironment(FSENVIRONMENT env);
 	void EnforceEnvironment(void);
 	FSENVIRONMENT GetEnvironment(void) const;
+	int GetDayLength(void) const;
+	double GetDayCycle(void) const;
+	void SetDayLength(int dayLength);
+	void SetDayCycle(double dayCycle);
+	
 
 	YSRESULT SendConfigString(const char str[]);
 

--- a/src/core/fsweather.h
+++ b/src/core/fsweather.h
@@ -15,6 +15,7 @@ public:
 
 	static const char *CloudLayerTypeString(int cloudLayerType);
 	static int CloudLayerTypeFromString(const char str[]);
+	FsWeatherCloudLayer Overcast(double y0,double y1); // Returns an overcast 
 };
 
 
@@ -30,6 +31,10 @@ protected:
 	double transFogVisibility;
 
 	YsArray <FsWeatherCloudLayer> cloudLayer;
+
+	YsColor daylightColour = YsColor(1.0,1.0,1.0); //Because it is spelled colour. Not color... uncultured swines.
+	YsColor nightColour = YsColor(0.1,0.1,0.3);
+	YsColor dawnColour = YsColor(1,0.5,0.0);
 
 public:
 	FsWeather();
@@ -52,12 +57,25 @@ public:
 	void SetCloudLayer(YSSIZE_T nLayer,const FsWeatherCloudLayer layer[]);
 	void AddCloudLayer(const FsWeatherCloudLayer &layer);
 	void GetCloudLayer(int &nLayer,const FsWeatherCloudLayer *&layer) const;
+	int GetCloudLayerCount() const;
 	YSBOOL IsInCloudLayer(const YsVec3 &pos) const;
 
 	YSRESULT Save(FILE *fp) const;
 	YSRESULT Load(FILE *fp);
 
 	void DrawCloudLayer(const YsVec3 &cameraPos) const;
+
+	//Day/Night cycle functions
+
+	YsColor GetLightColour(const double dayTime) const;
+	YsColor GetLightColour(YsColor skyColour, const double dayTime) const;
+	double GetLightIntensity(const double dayTime) const;
+	double ColourInterpolate(const double colour1, const double colour2, const double i) const;
+	YSBOOL IsDay(const double dayTime) const;
+	YSBOOL IsDuskOrDawn(const double dayTime) const;
+	double DuskIntensity(const double dayTime) const;
+	void GetDayTime(double& daytime, double dt, int dayLength) const;
+	void SetSunPosition(YsVec3& lightPosition, double dayTime) const;
 };
 
 

--- a/src/graphics/common/fsopengl.h
+++ b/src/graphics/common/fsopengl.h
@@ -59,6 +59,7 @@ void FsClearStencilBuffer(void);
 void FsSetPerPixelShading(YSBOOL perPix);
 void FsSetPointLight(const YsVec3 &cameraPosition,const YsVec3 &lightPosition,FSENVIRONMENT env);
 void FsSetDirectionalLight(const YsVec3 &cameraPosition,const YsVec3 &lightDirection,FSENVIRONMENT env);
+void FsSetDirectionalLight(const YsVec3 &cameraPosition, const YsVec3 &lightDirection, FSENVIRONMENT env, const YsColor &lightColor, const double &lightLevel);
 void FsFogOn(const YsColor &fogColor,const double &visibility);
 void FsFogOff(void);
 

--- a/src/graphics/d3d9/fsd3d.cpp
+++ b/src/graphics/d3d9/fsd3d.cpp
@@ -269,6 +269,62 @@ void FsSetDirectionalLight(const YsVec3 &cameraPosition,const YsVec3 &lightDirec
 	}
 }
 
+void FsSetDirectionalLight(const YsVec3 &/*cameraPosition*/, const YsVec3 &lightDirection, FSENVIRONMENT env, const YsColor &lightColor, const int &lightLevel){
+	auto ysD3dDev=YsD3dDevice::GetCurrent();
+	if(ysD3dDev!=NULL)
+	{
+		D3DVECTOR lightDir;
+		D3DLIGHT9 light;
+		ZeroMemory(&light,sizeof(light));
+		light.Type=D3DLIGHT_DIRECTIONAL;
+
+		switch(env)
+		{
+		case FSDAYLIGHT:
+			light.Diffuse.r=0.6F;
+			light.Diffuse.g=0.6F;
+			light.Diffuse.b=0.6F;
+			light.Diffuse.a=1.0;
+
+			light.Ambient.r=0.3F;
+			light.Ambient.g=0.3F;
+			light.Ambient.b=0.3F;
+			light.Ambient.a=1.0F;
+
+			light.Specular.r=0.9F;
+			light.Specular.g=0.9F;
+			light.Specular.b=0.9F;
+			light.Specular.a=1.0F;
+			break;
+		case FSNIGHT:
+			light.Diffuse.r=0.05F;
+			light.Diffuse.g=0.05F;
+			light.Diffuse.b=0.05F;
+			light.Diffuse.a=1.0;
+
+			light.Ambient.r=0.05F;
+			light.Ambient.g=0.05F;
+			light.Ambient.b=0.05F;
+			light.Ambient.a=1.0F;
+
+			light.Specular.r=0.0F;
+			light.Specular.g=0.0F;
+			light.Specular.b=0.0F;
+			light.Specular.a=1.0F;
+			break;
+		}
+
+		lightDir.x=(float)-lightDirection.x();
+		lightDir.y=(float)-lightDirection.y();
+		lightDir.z=(float)-lightDirection.z();
+		YsD3dNormalize(light.Direction,lightDir);
+		light.Range=100.0F;
+		ysD3dDev->d3dDev->SetLight(0,&light);
+		ysD3dDev->d3dDev->LightEnable(0,TRUE);
+		ysD3dDev->d3dDev->SetRenderState(D3DRS_LIGHTING,TRUE);
+	}
+}
+
 void FsFogOn(const YsColor &col,const double &visibility)
 {
 	auto ysD3dDev=YsD3dDevice::GetCurrent();

--- a/src/graphics/gl/fsopengl.cpp
+++ b/src/graphics/gl/fsopengl.cpp
@@ -367,6 +367,49 @@ void FsSetDirectionalLight(const YsVec3 &cameraPosition,const YsVec3 &lightDirec
 	FsResetMaterial();
 }
 
+void FsSetDirectionalLight(const YsVec3 &/*cameraPosition*/, const YsVec3 &lightDirection, FSENVIRONMENT env, const YsColor &lightColor, const double &lightLevel){
+	float light[4];
+//TODO - Need to apply the light level and colour here to DAYLIGHT.
+#ifdef YSOGLERRORCHECK
+	FsOpenGlShowError("FsSetDirectionalLight In");
+#endif
+
+	light[0]=(float)lightDirection.x();
+	light[1]=(float)lightDirection.y();
+	light[2]=(float)lightDirection.z();
+	light[3]=0.0;
+	glLightfv(GL_LIGHT0,GL_POSITION,light);
+
+	GLfloat dif[4];
+	GLfloat amb[4];
+	GLfloat spc[4];
+
+	dif[0]=(float) 0.6 * lightColor.Rd() * lightLevel;
+	dif[1]=(float) 0.6 * lightColor.Gd() * lightLevel;
+	dif[2]=(float) 0.6 * lightColor.Bd() * lightLevel;
+	dif[3]=1.0F;
+
+	amb[0]=0.3F * lightColor.Rd() * lightLevel;
+	amb[1]=0.3F * lightColor.Gd() * lightLevel;
+	amb[2]=0.3F * lightColor.Bd() * lightLevel;
+	amb[3]=1.0F;
+
+	spc[0]=0.9F * lightColor.Rd() * lightLevel;
+	spc[1]=0.9F * lightColor.Gd() * lightLevel;
+	spc[2]=0.9F * lightColor.Bd() * lightLevel;
+	spc[3]=1.0F;
+
+	glLightfv(GL_LIGHT0,GL_DIFFUSE,dif);
+	glLightfv(GL_LIGHT0,GL_AMBIENT,amb);
+	glLightfv(GL_LIGHT0,GL_SPECULAR,spc);
+
+#ifdef YSOGLERRORCHECK
+	FsOpenGlShowError("FsSetDirectionalLight Out");
+#endif
+
+	FsResetMaterial();
+}
+
 void FsFogOn(const YsColor &col,const double &visibility)
 {
 	float fogColor[]={0.7F,0.7F,0.7F,0.0F};

--- a/src/graphics/gl2.0/fsopengl2.0.cpp
+++ b/src/graphics/gl2.0/fsopengl2.0.cpp
@@ -460,6 +460,66 @@ void FsSetDirectionalLight(const YsVec3 &/*cameraPosition*/ ,const YsVec3 &light
 #endif
 }
 
+
+void FsSetDirectionalLight(const YsVec3 &/*cameraPosition*/, const YsVec3 &lightDirection, FSENVIRONMENT env, const YsColor &lightColor, const double &lightLevel){
+#ifdef YSOGLERRORCHECK
+	FsOpenGlShowError("FsSetDirectionalLight In");
+#endif
+
+	const GLfloat light[4]=
+	{
+		(GLfloat)lightDirection.x(),
+		(GLfloat)lightDirection.y(),
+		(GLfloat)lightDirection.z(),
+		0.0f
+	};
+
+	GLfloat dif[4];
+	GLfloat amb[4];
+	GLfloat spc[4];
+
+	dif[0]=(float) 0.6 * lightColor.Rd() * lightLevel;
+	dif[1]=(float) 0.6 * lightColor.Gd() * lightLevel;
+	dif[2]=(float) 0.6 * lightColor.Bd() * lightLevel;
+	dif[3]=1.0F;
+
+	amb[0]=0.3F * lightColor.Rd() * lightLevel;
+	amb[1]=0.3F * lightColor.Gd() * lightLevel;
+	amb[2]=0.3F * lightColor.Bd() * lightLevel;
+	amb[3]=1.0F;
+
+	spc[0]=0.9F * lightColor.Rd() * lightLevel;
+	spc[1]=0.9F * lightColor.Gd() * lightLevel;
+	spc[2]=0.9F * lightColor.Bd() * lightLevel;
+	spc[3]=1.0F;
+
+
+	YsGLSLSetShared3DRendererDirectionalLightfv(0,light);
+	YsGLSLSetShared3DRendererLightColor(0,dif);
+	YsGLSLSetShared3DRendererAmbientColor(amb);
+	YsGLSLSetShared3DRendererSpecularColor(spc);
+
+	YsGLSLUse3DRenderer(YsGLSLSharedFlash3DRenderer());
+	switch(env)
+	{
+	case FSDAYLIGHT:
+		YsGLSLSet3DRendererUniformFlashSize(YsGLSLSharedFlash3DRenderer(),0.1f);
+		YsGLSLSet3DRendererFlashRadius(YsGLSLSharedFlash3DRenderer(),0.6f,1.0f);
+		break;
+	case FSNIGHT:
+		YsGLSLSet3DRendererUniformFlashSize(YsGLSLSharedFlash3DRenderer(),1.0f);
+		YsGLSLSet3DRendererFlashRadius(YsGLSLSharedFlash3DRenderer(),0.2f,1.0f);
+		break;
+	}
+	YsGLSLEndUse3DRenderer(YsGLSLSharedFlash3DRenderer());
+
+
+#ifdef YSOGLERRORCHECK
+	FsOpenGlShowError("FsSetDirectionalLight Out");
+#endif
+
+}
+
 void FsFogOn(const YsColor &col,const double &visibility)
 {
 #ifdef YSOGLERRORCHECK

--- a/src/graphics/null/fsnownd.cpp
+++ b/src/graphics/null/fsnownd.cpp
@@ -93,6 +93,9 @@ void FsSetDirectionalLight(const YsVec3 &cameraPosition,const YsVec3 &lightDirec
 {
 }
 
+void FsSetDirectionalLight(const YsVec3 &/*cameraPosition*/, const YsVec3 &lightDirection, FSENVIRONMENT env, const YsColor &lightColor, const double &lightLevel){
+}
+
 void FsFogOn(const YsColor &fogColor,const double &visibility)
 {
 }

--- a/src/platform/linux/fsnullnetwork.cpp
+++ b/src/platform/linux/fsnullnetwork.cpp
@@ -643,7 +643,7 @@ YSRESULT FsSocketClient::ReceiveAssignSideWindow(unsigned char dat[])
 	return YSERR;
 }
 
-YSRESULT FsSocketClient::ReceiveVersionNotify(unsigned char dat[])
+YSRESULT FsSocketClient::ReceiveVersionNotify(unsigned packetLength, unsigned char dat[])
 {
 	return YSERR;
 }


### PR DESCRIPTION
Implementation of day/night cycle.

Day/Night cycle is measured on a scale of 2 pi. 0 is mid-day, Pi is mid-night, and 2pi is mid-day the next day (resets back to 0)
![image](https://github.com/YSCEDC/YSCE/assets/28678069/f7ad9641-bbf9-40c2-9c3e-009c67664f10)

Dusks/dawns are between 0.2 > sin(dayTime + pi/2) <-0.2.

Conversion between dayTime and 24h clock would be:
* For times up to midnight (pi) = dayTime / (2Pi/24)+12
* For times after midnight (>pi) = dayTime/(2Pi/24)-12

Will implement a method for conversion

For net code:
Combined with the cloud layers config stuff I was working on before with the sending of the day/night cycle.

Cloud layers set in the config settings window now follow through into multiplayer, and will be sent to clients.

Clients are only sent the new stuff if they're running YSCE too. There is a check on the login process to see whether the client is using YSCE, and if so, that info is stored for any other future netcode changes that may need a YSCE switch.

Currently the day/night cycle doesn't re-send the day/night time when it changes. This needs adding, but in a sensible way that doesn't resend it every tick...

On login, the day length is sent to the client, along with the current position in the day/night cycle, so the client is able to keep track of it their side. It will resend when the day/night switch occurs, but it doesn't yet.