### PR TITLE
Working look up and down sub windows

### DIFF
--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -10827,6 +10827,8 @@ void FsSimulation::SimDecideViewpoint_Air(ActualViewMode &actualViewMode,FSVIEWM
 	case FS45DEGREELEFTVIEW:
 	case FS90DEGREERIGHTVIEW:
 	case FS90DEGREELEFTVIEW:
+	case FSVIEWUP:
+	case FSVIEWDOWN:
 	case FSADDITIONALAIRPLANEVIEW:
 	case FSOUTSIDEPLAYER2:
 	case FSOUTSIDEPLAYER3:
@@ -10910,6 +10912,8 @@ void FsSimulation::SimDecideViewpoint_Gnd(ActualViewMode &actualViewMode,FSVIEWM
 	case FS45DEGREELEFTVIEW:
 	case FS90DEGREERIGHTVIEW:
 	case FS90DEGREELEFTVIEW:
+	case FSVIEWUP:
+	case FSVIEWDOWN:
 	case FSADDITIONALAIRPLANEVIEW:
 	case FSOUTSIDEPLAYER2:
 	case FSOUTSIDEPLAYER3:
@@ -11106,6 +11110,8 @@ void FsSimulation::SimDecideViewpoint_Common(ActualViewMode &actualViewMode,FSVI
 	case FS45DEGREELEFTVIEW:
 	case FS90DEGREERIGHTVIEW:
 	case FS90DEGREELEFTVIEW:
+	case FSVIEWUP:
+	case FSVIEWDOWN:
 		switch(mode)
 		{
 		case FSBACKMIRRORVIEW:
@@ -11127,6 +11133,14 @@ void FsSimulation::SimDecideViewpoint_Common(ActualViewMode &actualViewMode,FSVI
 		case FS90DEGREELEFTVIEW:
 			actualViewMode.actualViewHdg=YsPi/2.0;
 			actualViewMode.actualViewPch=0.0;
+			break;
+		case FSVIEWUP:
+			actualViewMode.actualViewPch=YsPi/2.0;
+			actualViewMode.actualViewHdg=0.0;
+			break;
+		case FSVIEWDOWN:
+			actualViewMode.actualViewPch=-YsPi/2.0;
+			actualViewMode.actualViewHdg=0.0;
 			break;
 		}
 

--- a/src/core/fssimulation.h
+++ b/src/core/fssimulation.h
@@ -149,7 +149,10 @@ public:
 		FSTURNVIEW,                     // 2005/06/07
 
 		FSADDITIONALAIRPLANEVIEW,       // 2006/07/19 For additional view in cockpit
-		FSADDITIONALAIRPLANEVIEW_CABIN  // 2011/02/01 For additional view in cabin
+		FSADDITIONALAIRPLANEVIEW_CABIN,  // 2011/02/01 For additional view in cabin
+
+		FSVIEWUP,
+		FSVIEWDOWN 					//Added 01/10/2023 - for subwindow view up and down
 	};
 	enum FSREPLAYMODE
 	{

--- a/src/core/fssubmenu.cpp
+++ b/src/core/fssubmenu.cpp
@@ -390,7 +390,19 @@ void FsSubMenu::ProcessSubMenu(class FsSimulation *sim,class FsFlightConfig &cfg
 				sim->SetSubWindowViewMode(windowId,FsSimulation::FSCOCKPITVIEW);
 				SetSubMenu(sim,FSSUBMENU_WAITKEYRELEASE);
 				break;
+
+			case FSKEY_8:
+				needOpen=YSTRUE;
+				sim->SetSubWindowViewMode(windowId,FsSimulation::FSVIEWUP);
+				SetSubMenu(sim,FSSUBMENU_WAITKEYRELEASE);
+				break;
+			case FSKEY_9:
+				needOpen=YSTRUE;
+				sim->SetSubWindowViewMode(windowId,FsSimulation::FSVIEWDOWN);
+				SetSubMenu(sim,FSSUBMENU_WAITKEYRELEASE);
+				break;
 			}
+			
 
 			if(needOpen==YSTRUE && FsIsSubWindowOpen(windowId)!=YSTRUE)
 			{
@@ -624,6 +636,13 @@ void FsSubMenu::Draw(const class FsSimulation *sim,class FsFlightConfig &cfg,int
 
 		FsDrawString(sx,sy,"7. Forward View",YsWhite());
 		sy+=fsAsciiRenderer.GetFontHeight();
+
+		FsDrawString(sx,sy,"8. View Up",YsWhite());
+		sy+=fsAsciiRenderer.GetFontHeight();
+
+		FsDrawString(sx,sy,"9. View Down",YsWhite());
+		sy+=fsAsciiRenderer.GetFontHeight();
+		
 
 		FsDrawString(sx,sy,"Enter: Back",YsWhite());
 		sy+=fsAsciiRenderer.GetFontHeight();


### PR DESCRIPTION
Added in the ability to set the sub-window to look up or down, in addition to left and right.
![image](https://github.com/YSCEDC/YSCE/assets/28678069/c94a6ada-c036-41a1-8773-5be177561c26)
(In F-15, can't really see the look down working.)

![image](https://github.com/YSCEDC/YSCE/assets/28678069/f8416139-3f7d-4af3-b961-8ededddd5393)
In concord, can see the look down working!