### PR TITLE
Improve object draw culling

### DIFF
--- a/src/core/fsexistence.cpp
+++ b/src/core/fsexistence.cpp
@@ -794,7 +794,7 @@ void FsAirplane::MakeVaporVertexArray(class YsGLVertexBuffer &vtxBuf,class YsGLC
 
 	if(nullptr!=rec)
 	{
-		YSSIZE_T idx;
+		YSSIZE_T idx{};
 		double t,t0,t1;
 
 		// Catch the index

--- a/src/core/fsexistence.cpp
+++ b/src/core/fsexistence.cpp
@@ -794,7 +794,7 @@ void FsAirplane::MakeVaporVertexArray(class YsGLVertexBuffer &vtxBuf,class YsGLC
 
 	if(nullptr!=rec)
 	{
-		YSSIZE_T idx{};
+		YSSIZE_T idx;
 		double t,t0,t1;
 
 		// Catch the index

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -7187,18 +7187,30 @@ void FsSimulation::SimDrawGround(const ActualViewMode &actualViewMode,const FsPr
 			}
 
 			//calculate object position in player's view
-			YsVec3 objViewPos, objPos;
+			YsVec3 objViewPos, objPos, objScreenPos;
 			objPos = seeker->GetPosition();
 			objViewPos = actualViewMode.viewMat * objPos;
 
+			//calculate apparent radius of object (view size)
 			double objRad,distance,apparentRad;
-
 			objRad=seeker->Prop().GetOutsideRadius();
 			distance=(seeker->GetPosition()-viewPoint).GetLength();
 			apparentRad=objRad*proj.prjPlnDist/distance;
 
-			// only draw if apparent radius is larger than 1 pixel AND object is in player view
-			if(apparentRad>=1 && objViewPos.z() + objRad >= 0.0)
+			//1/2 of vertical and horizontal FOVs
+			double fovHorizontal = atan(proj.tanFov);
+			double fovVertical = atan(proj.tanFovSecondary);
+
+			//calculate relative (unsigned) XZ & YZ angles of object from camera view vector
+			double objRadiusViewAngleOffset = atan2(objRad, abs(objViewPos.z()));
+			double objHorizontalViewAngle = atan2(abs(objViewPos.x()), abs(objViewPos.z()));
+			double objVerticalViewAngle = atan2(abs(objViewPos.y()), abs(objViewPos.z()));
+
+			// only draw if apparent radius is larger than 1 pixel AND object is within camera's view
+			if(apparentRad>=1 
+				&& objViewPos.z() + objRad >= 0.0 
+				&& objHorizontalViewAngle <= fovHorizontal + objRadiusViewAngleOffset 
+				&& objVerticalViewAngle <= fovVertical + objRadiusViewAngleOffset)
 			{
 				switch(cfgPtr->gndLod)
 				{
@@ -7224,6 +7236,7 @@ void FsSimulation::SimDrawGround(const ActualViewMode &actualViewMode,const FsPr
 					break;
 				}
 			}
+
 		}
 
 		if((actualViewMode.actualViewMode==FSCOCKPITVIEW ||
@@ -9696,9 +9709,10 @@ void FsSimulation::GetProjection(FsProjection &prj,const ActualViewMode &actualV
 	fovInPixel=YsGreater(wid/2,hei/2);  // 2010/07/05 It was ...,prj.cx,prj.cy);
 
 	prj.prjMode=YsProjectionTransformation::PERSPECTIVE;
-	prj.prjPlnDist=(double)hei/(1.41421356*720.0/960.0);  // 2010/07/05 Fix vertical fov (double)wid/(double)1.41421356;
+	prj.prjPlnDist=(double)hei/(1.41421356 * 0.75);  // 2010/07/05 Fix vertical fov (double)wid/(double)1.41421356;
 	prj.prjPlnDist*=(actualViewMode.viewMagFix*viewMagUser/1.8);
 	prj.tanFov=(double)fovInPixel/prj.prjPlnDist;
+	prj.tanFovSecondary = (double)YsSmaller(wid / 2, hei / 2) / prj.prjPlnDist;
 	prj.viewportDim.Set(wid,hei);
 
 	prj.nearz=0.1;

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -7114,7 +7114,7 @@ void FsSimulation::SimDrawAirplane(const ActualViewMode &actualViewMode,const Fs
 				// Otherwise, Weapon LOD depends on drawCoarseOrdinance
 
 				//calculate object position in player's view
-				YsVec3 objViewPos, objPos, objScreenPos;
+				YsVec3 objViewPos, objPos;
 				objPos = seeker->GetPosition();
 				objViewPos = actualViewMode.viewMat * objPos;
 
@@ -7214,7 +7214,7 @@ void FsSimulation::SimDrawGround(const ActualViewMode &actualViewMode,const FsPr
 			}
 
 			//calculate object position in player's view
-			YsVec3 objViewPos, objPos, objScreenPos;
+			YsVec3 objViewPos, objPos;
 			objPos = seeker->GetPosition();
 			objViewPos = actualViewMode.viewMat * objPos;
 

--- a/src/graphics/common/fsopengl.h
+++ b/src/graphics/common/fsopengl.h
@@ -16,7 +16,8 @@ public:
 //   | /
 //   |/
 //   V
-	double tanFov;      // Tangent of field of view (FOV)
+	double tanFov;          // Tangent of field of view (FOV) along the longer (primary) screen axis
+	double tanFovSecondary; // Tangent of field of view (FOV) along the shorter (secondary) screen axis
 	double prjPlnDist;  // =scrnwidth/(2*tanFov)
 	double nearz,farz;
 	YsVec2i viewportDim;


### PR DESCRIPTION
Vanilla YSFLIGHT only checks that the apparent radius of an object (screen size) is >=1 prior to drawing it.
Originally, we enhanced this check to also require that the object is in-front of the camera.
This check is further enhanced to also check that the object is within the camera's field of view. Aircraft are also culled now. 