### PR TITLE
Fix culling issues 

### DIFF
--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -309,6 +309,7 @@ FsSimulation::FsSimulation(FsWorld *w) : airplaneList(FsAirplaneAllocator),groun
 	//lastProjection();
 	lastWindowWidth = 0;
 	lastWindowHeight = 0;
+	lastViewMagUser = 1.0;
 }
 
 FsSimulation::~FsSimulation()
@@ -9735,10 +9736,11 @@ void FsSimulation::GetProjection(FsProjection &prj,const ActualViewMode &actualV
 		prj.cy = hei / 2;
 	}
 
-	if (wid != lastWindowWidth || hei != lastWindowHeight)
+	if (wid != lastWindowWidth || hei != lastWindowHeight || viewMagUser != lastViewMagUser)
 	{
 		lastWindowWidth = wid;
 		lastWindowHeight = hei;
+		lastViewMagUser = viewMagUser;
 
 		prj.fovInPixels = YsGreater(wid / 2, hei / 2);  // 2010/07/05 It was ...,prj.cx,prj.cy);
 

--- a/src/core/fssimulation.cpp
+++ b/src/core/fssimulation.cpp
@@ -7177,10 +7177,14 @@ bool FsSimulation::IsObjectVisible(FsExistence* obj, const ActualViewMode& actua
 
 	//calculate apparent radius of object (view size)
 
+	//load visual bounding box
+	YsVec3 boxMin, boxMax;
+	obj->vis.GetBoundingBox(boxMin, boxMax);
+
 	//load collision box corners
-	auto collBox = obj->GetCollisionShellBbx();
-	YsVec3 boxMin = collBox[0];
-	YsVec3 boxMax = collBox[1];
+	//auto collBox = obj->GetCollisionShellBbx();
+	//YsVec3 boxMin = collBox[0];
+	//YsVec3 boxMax = collBox[1];
 	YsVec3 corner[8];
 	corner[0].Set(boxMin.x(), boxMin.y(), boxMin.z());
 	corner[1].Set(boxMax.x(), boxMin.y(), boxMin.z());

--- a/src/core/fssimulation.h
+++ b/src/core/fssimulation.h
@@ -99,6 +99,7 @@ private:
 	FsProjection lastProjection;
 	int lastWindowWidth;
 	int lastWindowHeight;
+	double lastViewMagUser;
 
 public:
 	enum FSSIMULATIONSTATE


### PR DESCRIPTION
#85 sometimes culled objects which were still within the FOV, this should fix that by tweaking the math used to check whether or not objects should be culled. 

Tested on Nellis with the problematic fences rendered succesfully