### PR TITLE
Fix std::string "incomplete type" compiler errors.

### DIFF
--- a/src/core/fshud2.cpp
+++ b/src/core/fshud2.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include <ysclass.h>
 #include <ysunitconv.h>
 #include "fs.h"

--- a/src/gui/fsguinetdialog.h
+++ b/src/gui/fsguinetdialog.h
@@ -2,6 +2,7 @@
 #define FSGUINETDIALOG_IS_INCLUDED
 /* { */
 
+#include <string>
 #include <fsgui.h>
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
The errors occur on Fedora 41.