### PR TITLE
Fix crash on close

### DIFF
--- a/src/main/fsmain.cpp
+++ b/src/main/fsmain.cpp
@@ -247,6 +247,11 @@ FsLazyWindowApplication::FsLazyWindowApplication()
 }
 /* virtual */ void FsLazyWindowApplication::BeforeTerminate(void)
 {
+	if(!runLoopPtr)
+	{
+		return;
+	}
+
 	FsTaskBarDeleteIcon();
 
 printf("Closing-1\n");
@@ -309,10 +314,13 @@ printf("Closing-11\n");
 }
 /* virtual */ bool FsLazyWindowApplication::UserWantToCloseProgram(void)
 {
-printf("%s %d\n",__FUNCTION__,__LINE__);
+	if(!runLoopPtr)
+	{
+		return true;
+	}
 	SaveWindowPositionAndSizeIfNecessary();
 	FsTaskBarDeleteIcon();
-	return true; // Returning true will just close the program.
+	return true;
 }
 /* virtual */ bool FsLazyWindowApplication::MustTerminate(void) const
 {

--- a/src/main_demoOnly/fsmain.cpp
+++ b/src/main_demoOnly/fsmain.cpp
@@ -248,6 +248,11 @@ FsLazyWindowApplication::FsLazyWindowApplication()
 }
 /* virtual */ void FsLazyWindowApplication::BeforeTerminate(void)
 {
+	if(!runLoopPtr)
+	{
+		return;
+	}
+
 	FsTaskBarDeleteIcon();
 
 printf("Closing-1\n");
@@ -310,10 +315,13 @@ printf("Closing-11\n");
 }
 /* virtual */ bool FsLazyWindowApplication::UserWantToCloseProgram(void)
 {
-printf("%s %d\n",__FUNCTION__,__LINE__);
+	if(!runLoopPtr)
+	{
+		return true;
+	}
 	SaveWindowPositionAndSizeIfNecessary();
 	FsTaskBarDeleteIcon();
-	return true; // Returning true will just close the program.
+	return true;
 }
 /* virtual */ bool FsLazyWindowApplication::MustTerminate(void) const
 {


### PR DESCRIPTION
Null check for runLoopPtr in BeforeTerminate and UserWantToCloseProgram to prevent crash when run loop is not initialized.